### PR TITLE
issue-111: removing .course_key deprecation warning

### DIFF
--- a/lms/djangoapps/courseware/model_data.py
+++ b/lms/djangoapps/courseware/model_data.py
@@ -1008,7 +1008,7 @@ def get_score(user_id, usage_key):
         student_module = StudentModule.objects.get(
             student_id=user_id,
             module_state_key=usage_key,
-            course_id=usage_key.course_key,
+            course_id=usage_key.context_key,
         )
     except StudentModule.DoesNotExist:
         return None

--- a/lms/djangoapps/courseware/user_state_client.py
+++ b/lms/djangoapps/courseware/user_state_client.py
@@ -278,18 +278,18 @@ class DjangoXBlockUserStateClient(XBlockUserStateClient):
             username (str): The name of the user to load `StudentModule`s for.
             block_keys (list of :class:`~UsageKey`): The set of XBlocks to load data for.
         """
-        course_key_func = attrgetter('course_key')
-        by_course = itertools.groupby(
-            sorted(block_keys, key=course_key_func),
-            course_key_func,
+        context_key_func = attrgetter('context_key')
+        by_context = itertools.groupby(
+            sorted(block_keys, key=context_key_func),
+            context_key_func,
         )
 
-        for course_key, usage_keys in by_course:
+        for context_key, usage_keys in by_context:
             query = StudentModule.objects.chunked_filter(
                 'module_state_key__in',
                 usage_keys,
                 student__username=username,
-                course_id=course_key,
+                course_id=context_key,
             )
 
             for student_module in query:

--- a/lms/djangoapps/grades/signals/handlers.py
+++ b/lms/djangoapps/grades/signals/handlers.py
@@ -181,7 +181,7 @@ def score_published_handler(sender, block, user, raw_earned, raw_possible, only_
             raw_possible=raw_possible,
             weight=getattr(block, 'weight', None),
             user_id=user.id,
-            course_id=str(block.location.course_key),
+            course_id=str(block.location.context_key),
             usage_id=str(block.location),
             only_if_higher=only_if_higher,
             modified=score_modified_time,

--- a/openedx/core/djangoapps/content_libraries/api.py
+++ b/openedx/core/djangoapps/content_libraries/api.py
@@ -1229,7 +1229,7 @@ class BaseEdxImportClient(abc.ABC):
 
         course_key_id = base64.b32encode(
             hashlib.blake2s(
-                str(modulestore_key.course_key).encode()
+                str(modulestore_key.context_key).encode()
             ).digest()
         )[:16].decode().lower()
         # Prepend 'c' to allow changing hash without conflicts.

--- a/openedx/core/lib/xblock_serializer/block_serializer.py
+++ b/openedx/core/lib/xblock_serializer/block_serializer.py
@@ -29,7 +29,7 @@ class XBlockSerializer:
         olx_node = self._serialize_block(block)
         self.olx_str = etree.tostring(olx_node, encoding="unicode", pretty_print=True)
 
-        course_key = self.orig_block_key.course_key
+        course_key = self.orig_block_key.context_key
         # Search the OLX for references to files stored in the course's
         # "Files & Uploads" (contentstore):
         self.olx_str = utils.rewrite_absolute_static_urls(self.olx_str, course_key)

--- a/xmodule/html_block.py
+++ b/xmodule/html_block.py
@@ -191,7 +191,7 @@ class HtmlBlockMixin(  # lint-amnesty, pylint: disable=abstract-method
         # Add some specific HTML rendering context when editing HTML blocks where we pass
         # the root /c4x/ url for assets. This allows client-side substitutions to occur.
         _context.update({
-            'base_asset_url': StaticContent.get_base_url_path_for_course_assets(self.location.course_key),
+            'base_asset_url': StaticContent.get_base_url_path_for_course_assets(self.location.context_key),
             'enable_latex_compiler': self.use_latex_compiler,
             'editor': self.editor
         })


### PR DESCRIPTION
<!--

🌳🌳
🌳🌳🌳🌳         🌳 Note: Quince is in support. Fixes you make on master may still be needed on Quince.
    🌳🌳🌳🌳     If so, make another pull request against the open-release/quince.master branch,
🌳🌳🌳🌳         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌳🌳

🌴🌴🌴🌴🌴🌴     🌴 Note: the Palm release is still supported.
                Please consider whether your change should be applied to Palm as well.

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

This pull request addresses [issue-111](https://github.com/openedx/public-engineering/issues/111) from the [openedx/public-engineering](https://github.com/openedx/public-engineering/issues) repository, removing the deprecation warning related to the use of `.course_key` in the [edx-platform](https://github.com/openedx/edx-platform) codebase.

The warning "[Deprecation Warning]: Use `.context_key` instead of `.course_key`" will no longer appear during GitHub Actions `unit-test` runs and in the `pytest-warnings` report.

This pull request removes 29 instances of the warning across 6 files.

### Impacts
This change primarily impacts developers who work on the [Open-edX Platform](https://github.com/openedx/edx-platform) and run the `unit-test` workflow files.

### Screenshots
No UI changes are associated with this pull request.

## Supporting information

For additional context, refer to [openedx/public-engineering Issue-111](https://github.com/openedx/public-engineering/issues/111) for a more detailed discussion on the deprecation warning and the necessity of this change.

## Testing instructions

To test this change:
1. Open [this link](https://github.com/minahilfaisal/edx-platform/actions/workflows/unit-tests-gh-hosted.yml?query=branch%3Abugfix%2Fissue-111%2Ffix-deprecation-warning) for accessing the `unit-tests-gh-hosted` action/workflow for this pull request.
2. Open one of the recent runs for this workflow, such as [this run](https://github.com/minahilfaisal/edx-platform/actions/runs/6851054222).
3. From the summary section, the `pytest-warnings-json` file can be downloaded, such as [this one](https://github.com/minahilfaisal/edx-platform/suites/18142430092/artifacts/1046259348).
4. Ensure that the deprecation warning related to `.course_key` no longer appears in any of the `pytest-warning` files.

## Deadline

None.

## Other information

- No dependencies on other changes.
- No special concerns or limitations.
- No database migrations are involved.