### PR TITLE
issue-97: removing add method deprecation warning

### DIFF
--- a/lms/djangoapps/course_wiki/plugins/markdownedx/mdx_mathjax.py
+++ b/lms/djangoapps/course_wiki/plugins/markdownedx/mdx_mathjax.py
@@ -23,7 +23,7 @@ class MathJaxPattern(markdown.inlinepatterns.Pattern):  # lint-amnesty, pylint: 
 class MathJaxExtension(markdown.Extension):
     def extendMarkdown(self, md, md_globals):  # lint-amnesty, pylint: disable=arguments-differ, unused-argument
         # Needs to come before escape matching because \ is pretty important in LaTeX
-        md.inlinePatterns.add('mathjax', MathJaxPattern(), '<escape')
+        md.inlinePatterns.register('mathjax', MathJaxPattern(), '<escape')
 
 
 def makeExtension(**kwargs):

--- a/lms/djangoapps/course_wiki/plugins/markdownedx/mdx_mathjax.py
+++ b/lms/djangoapps/course_wiki/plugins/markdownedx/mdx_mathjax.py
@@ -23,7 +23,7 @@ class MathJaxPattern(markdown.inlinepatterns.Pattern):  # lint-amnesty, pylint: 
 class MathJaxExtension(markdown.Extension):
     def extendMarkdown(self, md, md_globals):  # lint-amnesty, pylint: disable=arguments-differ, unused-argument
         # Needs to come before escape matching because \ is pretty important in LaTeX
-        md.inlinePatterns.register(MathJaxPattern(), 'mathjax', '<escape')
+        md.inlinePatterns.register(MathJaxPattern(), 'mathjax', 40)
 
 
 def makeExtension(**kwargs):

--- a/lms/djangoapps/course_wiki/plugins/markdownedx/mdx_mathjax.py
+++ b/lms/djangoapps/course_wiki/plugins/markdownedx/mdx_mathjax.py
@@ -23,7 +23,7 @@ class MathJaxPattern(markdown.inlinepatterns.Pattern):  # lint-amnesty, pylint: 
 class MathJaxExtension(markdown.Extension):
     def extendMarkdown(self, md, md_globals):  # lint-amnesty, pylint: disable=arguments-differ, unused-argument
         # Needs to come before escape matching because \ is pretty important in LaTeX
-        md.inlinePatterns.register('mathjax', MathJaxPattern(), '<escape')
+        md.inlinePatterns.register(MathJaxPattern(), 'mathjax', '<escape')
 
 
 def makeExtension(**kwargs):

--- a/lms/djangoapps/course_wiki/plugins/markdownedx/mdx_video.py
+++ b/lms/djangoapps/course_wiki/plugins/markdownedx/mdx_video.py
@@ -164,7 +164,7 @@ class VideoExtension(markdown.Extension):  # lint-amnesty, pylint: disable=missi
         pattern = klass(re)
         pattern.md = md
         pattern.ext = self
-        md.inlinePatterns.register(pattern, name, "<reference")
+        md.inlinePatterns.register(pattern, name, 40)
 
     def extendMarkdown(self, md, md_globals):  # lint-amnesty, pylint: disable=arguments-differ, unused-argument
         self.add_inline(md, 'bliptv', Bliptv,

--- a/lms/djangoapps/course_wiki/plugins/markdownedx/mdx_video.py
+++ b/lms/djangoapps/course_wiki/plugins/markdownedx/mdx_video.py
@@ -164,7 +164,7 @@ class VideoExtension(markdown.Extension):  # lint-amnesty, pylint: disable=missi
         pattern = klass(re)
         pattern.md = md
         pattern.ext = self
-        md.inlinePatterns.add(name, pattern, "<reference")
+        md.inlinePatterns.register(name, pattern, "<reference")
 
     def extendMarkdown(self, md, md_globals):  # lint-amnesty, pylint: disable=arguments-differ, unused-argument
         self.add_inline(md, 'bliptv', Bliptv,

--- a/lms/djangoapps/course_wiki/plugins/markdownedx/mdx_video.py
+++ b/lms/djangoapps/course_wiki/plugins/markdownedx/mdx_video.py
@@ -164,7 +164,7 @@ class VideoExtension(markdown.Extension):  # lint-amnesty, pylint: disable=missi
         pattern = klass(re)
         pattern.md = md
         pattern.ext = self
-        md.inlinePatterns.register(name, pattern, "<reference")
+        md.inlinePatterns.register(pattern, name, "<reference")
 
     def extendMarkdown(self, md, md_globals):  # lint-amnesty, pylint: disable=arguments-differ, unused-argument
         self.add_inline(md, 'bliptv', Bliptv,


### PR DESCRIPTION
<!--

🌳🌳
🌳🌳🌳🌳         🌳 Note: Quince is in support. Fixes you make on master may still be needed on Quince.
    🌳🌳🌳🌳     If so, make another pull request against the open-release/quince.master branch,
🌳🌳🌳🌳         or ask in the #wg-build-test-release Slack channel if you have any questions or need help.
🌳🌳

🌴🌴🌴🌴🌴🌴     🌴 Note: the Palm release is still supported.
                Please consider whether your change should be applied to Palm as well.

Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://open-edx-proposals.readthedocs.io/en/latest/oep-0051-bp-conventional-commits.html

Use this template as a guide. Omit sections that don't apply.
You may link to information rather than copy it, but only if the link is publicly
readable.  If you must linked information must be private (because it has secrets),
clearly label the link as private.

-->

## Description

This pull request addresses [issue-97](https://github.com/openedx/public-engineering/issues/97) from the [openedx/public-engineering](https://github.com/openedx/public-engineering/issues) repository, removing the deprecation warning related to the use of `add` method in the [edx-platform](https://github.com/openedx/edx-platform) codebase.

The warning "[Deprecation Warning]: Using the add method to register a processor or pattern is deprecated. Use the register method instead." will no longer appear in `lms` during GitHub Actions `unit-test` runs and in the `pytest-warnings` report.

This pull request removes 12 instances of the warning across 2 files.

### Impacts
This change primarily impacts developers who work on the [Open-edX Platform](https://github.com/openedx/edx-platform) and run the `unit-test` workflow files.

### Screenshots
No UI changes are associated with this pull request.

## Supporting information

For additional context, refer to [openedx/public-engineering Issue-111](https://github.com/openedx/public-engineering/issues/97) for a more detailed discussion on the deprecation warning and the necessity of this change.

## Testing instructions

To test this change:
1. Access the `unit-tests-gh-hosted` action/workflow for this pull request.
2. Open one of the recent runs for this workflow.
3. From the summary section, the `pytest-warnings-json` file can be downloaded.
4. Ensure that the deprecation warning related to using the `add` method to register a processor or pattern no longer appears in any of the `pytest-warning` files for `lms`.

## Deadline

None.

## Other information

- No dependencies on other changes.
- No special concerns or limitations.
- No database migrations are involved.