### PR TITLE
issue-89: removing runtime.render_template method deprecation warning 

### DIFF
--- a/lms/djangoapps/courseware/tests/test_block_render.py
+++ b/lms/djangoapps/courseware/tests/test_block_render.py
@@ -2817,7 +2817,8 @@ class LmsModuleSystemShimTest(SharedModuleStoreTestCase):
 
     def test_render_template(self):
         rendered = self.block.runtime.service(self.block, 'mako').render_template(
-            'templates/edxmako.html', {'element_id': 'hi'}
+            'templates/edxmako.html',
+            {'element_id': 'hi'}
         )  # pylint: disable=not-callable
         assert rendered == '<div id="hi" ns="main">Testing the MakoService</div>\n'
 

--- a/lms/djangoapps/courseware/tests/test_block_render.py
+++ b/lms/djangoapps/courseware/tests/test_block_render.py
@@ -2816,7 +2816,9 @@ class LmsModuleSystemShimTest(SharedModuleStoreTestCase):
             assert self.block.runtime.get_real_user() == self.user
 
     def test_render_template(self):
-        rendered = self.block.runtime.service(self.block, 'mako').render_template('templates/edxmako.html', {'element_id': 'hi'})  # pylint: disable=not-callable
+        rendered = self.block.runtime.service(self.block, 'mako').render_template(
+            'templates/edxmako.html', {'element_id': 'hi'}
+        )  # pylint: disable=not-callable
         assert rendered == '<div id="hi" ns="main">Testing the MakoService</div>\n'
 
     @override_settings(COURSES_WITH_UNSAFE_CODE=[r'course-v1:edX\+LmsModuleShimTest\+2021_Fall'])

--- a/lms/djangoapps/courseware/tests/test_block_render.py
+++ b/lms/djangoapps/courseware/tests/test_block_render.py
@@ -2816,7 +2816,7 @@ class LmsModuleSystemShimTest(SharedModuleStoreTestCase):
             assert self.block.runtime.get_real_user() == self.user
 
     def test_render_template(self):
-        rendered = self.block.runtime.render_template('templates/edxmako.html', {'element_id': 'hi'})  # pylint: disable=not-callable
+        rendered = self.block.runtime.service(self.block, 'mako').render_template('templates/edxmako.html', {'element_id': 'hi'})  # pylint: disable=not-callable
         assert rendered == '<div id="hi" ns="main">Testing the MakoService</div>\n'
 
     @override_settings(COURSES_WITH_UNSAFE_CODE=[r'course-v1:edX\+LmsModuleShimTest\+2021_Fall'])

--- a/lms/djangoapps/courseware/tests/test_lti_integration.py
+++ b/lms/djangoapps/courseware/tests/test_lti_integration.py
@@ -117,7 +117,10 @@ class TestLTI(BaseTestXmodule):
 
     def test_lti_constructor(self):
         generated_content = self.block.student_view(None).content
-        expected_content = self.block.runtime.service(self.block, 'mako').render_template('lti.html', self.expected_context)
+        expected_content = self.block.runtime.service(self.block, 'mako').render_template(
+            'lti.html',
+            self.expected_context
+        )
         assert generated_content == expected_content
 
     def test_lti_preview_handler(self):

--- a/lms/djangoapps/courseware/tests/test_lti_integration.py
+++ b/lms/djangoapps/courseware/tests/test_lti_integration.py
@@ -117,12 +117,15 @@ class TestLTI(BaseTestXmodule):
 
     def test_lti_constructor(self):
         generated_content = self.block.student_view(None).content
-        expected_content = self.runtime.render_template('lti.html', self.expected_context)
+        expected_content = self.block.runtime.service(self.block, 'mako').render_template('lti.html', self.expected_context)
         assert generated_content == expected_content
 
     def test_lti_preview_handler(self):
         generated_content = self.block.preview_handler(None, None).body
-        expected_content = self.runtime.render_template('lti_form.html', self.expected_context)
+        expected_content = self.block.runtime.service(self.block, 'mako').render_template(
+            'lti_form.html',
+            self.expected_context
+        )
         assert generated_content.decode('utf-8') == expected_content
 
 

--- a/lms/djangoapps/courseware/tests/test_word_cloud.py
+++ b/lms/djangoapps/courseware/tests/test_word_cloud.py
@@ -229,4 +229,7 @@ class TestWordCloud(BaseTestXmodule):
             'submitted': False,  # default value,
         }
 
-        assert fragment.content == self.runtime.render_template('word_cloud.html', expected_context)
+        assert fragment.content == self.block.runtime.service(self.block, 'mako').render_template(
+            'word_cloud.html',
+            expected_context
+        )

--- a/xmodule/mako_block.py
+++ b/xmodule/mako_block.py
@@ -46,7 +46,7 @@ class MakoTemplateBlockBase:
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        if getattr(self.runtime, 'render_template', None) is None:
+        if getattr(self.runtime.service(self, 'mako'), 'render_template', None) is None:
             raise TypeError(
                 '{runtime} must have a render_template function'
                 ' in order to use a MakoDescriptor'.format(

--- a/xmodule/mako_block.py
+++ b/xmodule/mako_block.py
@@ -46,10 +46,10 @@ class MakoTemplateBlockBase:
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        if getattr(self.runtime.service(self, 'mako'), 'render_template', None) is None:
+        if getattr(self.runtime, 'service', None) is None:
             raise TypeError(
-                '{runtime} must have a render_template function'
-                ' in order to use a MakoDescriptor'.format(
+                '{runtime} must have a service function that can be used to call the render_template'
+                'function of the MakoService in order to use a MakoDescriptor'.format(
                     runtime=self.runtime,
                 )
             )


### PR DESCRIPTION
## Description

This pull request addresses [issue-89](https://github.com/openedx/public-engineering/issues/89) from the [openedx/public-engineering](https://github.com/openedx/public-engineering/issues) repository, removing the deprecation warning related to the use of `runtime.render_template` in the [edx-platform](https://github.com/openedx/edx-platform) codebase.

The warning "[Deprecation Warning]: Use of runtime.render_template is deprecated. Use MakoService.render_template or a JavaScript-based template instead." will no longer appear during GitHub Actions `unit-test` runs and in the `pytest-warnings` report.

This pull request removes 11,574 instances of the warning across 16 `pytest_warnings_*.json` files.

### Impacts
This change primarily impacts developers who work on the [Open-edX Platform](https://github.com/openedx/edx-platform) and run the `unit-test` workflow files.

### Important
- [ ] Commit [825e8050](https://github.com/minahilfaisal/edx-platform/pull/5/commits/8774c4c7d8a051680c69e8f2b904a1dc825e8050) needs attention, review and proper testing to ensure that the new code does not break.

### Screenshots
No UI changes are associated with this pull request.

## Supporting information

For additional context, refer to [openedx/public-engineering Issue-89](https://github.com/openedx/public-engineering/issues/89) for a more detailed discussion on the deprecation warning and the necessity of this change.

## Testing instructions

To test this change:
1. Access the `unit-tests-gh-hosted` action/workflow for this pull request.
2. Open one of the recent runs for this workflow.
3. From the summary section, download the `pytest-warnings-json`.
4. Ensure that the deprecation warning related to `runtime.render_template` no longer appears in any of the `pytest-warning` files.

## Deadline

None.

## Other information

- No dependencies on other changes.
- No special concerns or limitations.
- No database migrations are involved.