### PR TITLE
issue-148: removing block.location deprecation warning

### DIFF
--- a/lms/djangoapps/courseware/model_data.py
+++ b/lms/djangoapps/courseware/model_data.py
@@ -712,7 +712,7 @@ class FieldDataCache:
         Add all `blocks` to this FieldDataCache.
         """
         if self.user.is_authenticated:
-            self.scorable_locations.update(block.location for block in blocks if block.has_score)
+            self.scorable_locations.update(block.scope_ids.usage_id for block in blocks if block.has_score)
             for scope, fields in self._fields_to_cache(blocks).items():
                 if scope not in self.cache:
                     continue


### PR DESCRIPTION
## Description

This pull request addresses [issue-148](https://github.com/openedx/public-engineering/issues/148) from the [openedx/public-engineering](https://github.com/openedx/public-engineering/issues) repository, removing the deprecation warning related to the use of `block.location` in the [edx-platform](https://github.com/openedx/edx-platform) codebase.

The warning "[Deprecation Warning]: Use of block.location should be replaced with block.scope_ids.usage_id." will no longer appear during GitHub Actions `unit-test` runs and in the `pytest-warnings` report.

This pull request removes 1 instance of the warning across 1 `pytest_warnings_*.json` files.

### Impacts
This change primarily impacts developers who work on the [Open-edX Platform](https://github.com/openedx/edx-platform) and run the `unit-test` workflow files.

### Screenshots
No UI changes are associated with this pull request.

## Supporting information

For additional context, refer to [openedx/public-engineering Issue-148](https://github.com/openedx/public-engineering/issues/148) for a more detailed discussion on the deprecation warning and the necessity of this change.

## Testing instructions

To test this change:
1. Access the `unit-tests-gh-hosted` action/workflow for this pull request.
2. Open one of the recent runs for this workflow.
3. From the summary section, download the `pytest-warnings-json`.
4. Ensure that the deprecation warning related to `block.location` no longer appears in any of the `pytest-warning` files.

## Deadline

None.

## Other information

- No dependencies on other changes.
- No special concerns or limitations.
- No database migrations are involved.