### PR TITLE
issue-106: removing runtime.cache deprecation warning

### DIFF
--- a/cms/djangoapps/contentstore/views/tests/test_preview.py
+++ b/cms/djangoapps/contentstore/views/tests/test_preview.py
@@ -276,8 +276,8 @@ class CmsModuleSystemShimTest(ModuleStoreTestCase):
         assert self.block.runtime.get_python_lib_zip() is None
 
     def test_cache(self):
-        assert hasattr(self.block.runtime.cache, 'get')
-        assert hasattr(self.block.runtime.cache, 'set')
+        assert hasattr(self.block.runtime._services.get('cache'), 'get')  # lint-amnesty, pylint: disable=protected-access
+        assert hasattr(self.block.runtime._services.get('cache'), 'set')  # lint-amnesty, pylint: disable=protected-access
 
     def test_replace_urls(self):
         html = '<a href="/static/id">'

--- a/lms/djangoapps/courseware/tests/test_block_render.py
+++ b/lms/djangoapps/courseware/tests/test_block_render.py
@@ -2850,8 +2850,8 @@ class LmsModuleSystemShimTest(SharedModuleStoreTestCase):
         assert self.block.runtime.get_python_lib_zip() is None
 
     def test_cache(self):
-        assert hasattr(self.block.runtime.cache, 'get')
-        assert hasattr(self.block.runtime.cache, 'set')
+        assert hasattr(self.block.runtime._services.get('cache'), 'get')  # lint-amnesty, pylint: disable=protected-access
+        assert hasattr(self.block.runtime._services.get('cache'), 'set')  # lint-amnesty, pylint: disable=protected-access
 
     @XBlock.register_temp_plugin(PureXBlock, 'pure')
     @XBlock.register_temp_plugin(PureXBlockWithChildren, identifier='xblock')


### PR DESCRIPTION
## Description

This pull request addresses [issue-106](https://github.com/openedx/public-engineering/issues/106) from the [openedx/public-engineering](https://github.com/openedx/public-engineering/issues) repository, removing the deprecation warning related to the use of `runtime.cache` in the [edx-platform](https://github.com/openedx/edx-platform) codebase.

The warning "[Deprecation Warning]: runtime.cache is deprecated. Please use the cache service instead." will no longer appear during GitHub Actions `unit-test` runs and in the `pytest-warnings` report.

This pull request removes 4 instances of the warning across 2 `pytest_warnings_*.json` files.

### Impacts
This change primarily impacts developers who work on the [Open-edX Platform](https://github.com/openedx/edx-platform) and run the `unit-test` workflow files.

### Screenshots
No UI changes are associated with this pull request.

## Supporting information

For additional context, refer to [openedx/public-engineering Issue-106](https://github.com/openedx/public-engineering/issues/106) for a more detailed discussion on the deprecation warning and the necessity of this change.

## Testing instructions

To test this change:
1. Access the `unit-tests-gh-hosted` action/workflow for this pull request.
2. Open one of the recent runs for this workflow.
3. From the summary section, download the `pytest-warnings-json`.
4. Ensure that the deprecation warning related to `runtime.cache` no longer appears in any of the `pytest-warning` files.

## Deadline

None.

## Other information

- No dependencies on other changes.
- No special concerns or limitations.
- No database migrations are involved.