### PR TITLE
issue-107: removing runtime.can_execute_unsafe_code deprecation warning

### DIFF
--- a/cms/djangoapps/contentstore/views/tests/test_preview.py
+++ b/cms/djangoapps/contentstore/views/tests/test_preview.py
@@ -251,10 +251,10 @@ class CmsModuleSystemShimTest(ModuleStoreTestCase):
 
     @override_settings(COURSES_WITH_UNSAFE_CODE=[r'course-v1:edX\+LmsModuleShimTest\+2021_Fall'])
     def test_can_execute_unsafe_code(self):
-        assert self.block.runtime.can_execute_unsafe_code()
+        assert self.block.runtime._services.get('sandbox').can_execute_unsafe_code()  # lint-amnesty, pylint: disable=protected-access
 
     def test_cannot_execute_unsafe_code(self):
-        assert not self.block.runtime.can_execute_unsafe_code()
+        assert not self.block.runtime._services.get('sandbox').can_execute_unsafe_code()  # lint-amnesty, pylint: disable=protected-access
 
     @override_settings(PYTHON_LIB_FILENAME=PYTHON_LIB_FILENAME)
     def test_get_python_lib_zip(self):

--- a/lms/djangoapps/courseware/tests/test_block_render.py
+++ b/lms/djangoapps/courseware/tests/test_block_render.py
@@ -2821,14 +2821,14 @@ class LmsModuleSystemShimTest(SharedModuleStoreTestCase):
 
     @override_settings(COURSES_WITH_UNSAFE_CODE=[r'course-v1:edX\+LmsModuleShimTest\+2021_Fall'])
     def test_can_execute_unsafe_code_when_allowed(self):
-        assert self.block.runtime.can_execute_unsafe_code()
+        assert self.block.runtime._services.get('sandbox').can_execute_unsafe_code()  # lint-amnesty, pylint: disable=protected-access
 
     @override_settings(COURSES_WITH_UNSAFE_CODE=[r'course-v1:edX\+full\+2021_Fall'])
     def test_cannot_execute_unsafe_code_when_disallowed(self):
-        assert not self.block.runtime.can_execute_unsafe_code()
+        assert not self.block.runtime._services.get('sandbox').can_execute_unsafe_code()  # lint-amnesty, pylint: disable=protected-access
 
     def test_cannot_execute_unsafe_code(self):
-        assert not self.block.runtime.can_execute_unsafe_code()
+        assert not self.block.runtime._services.get('sandbox').can_execute_unsafe_code()  # lint-amnesty, pylint: disable=protected-access
 
     @override_settings(PYTHON_LIB_FILENAME=PYTHON_LIB_FILENAME)
     def test_get_python_lib_zip(self):


### PR DESCRIPTION
## Description

This pull request addresses [issue-107](https://github.com/openedx/public-engineering/issues/107) from the [openedx/public-engineering](https://github.com/openedx/public-engineering/issues) repository, removing the deprecation warning related to the use of `runtime.can_execute_unsafe_code` in the [edx-platform](https://github.com/openedx/edx-platform) codebase.

The warning "[Deprecation Warning]: runtime.can_execute_unsafe_code is deprecated. Please use the sandbox service instead." will no longer appear during GitHub Actions `unit-test` runs and in the `pytest-warnings` report.

This pull request removes 5 instances of the warning across 2 `pytest_warnings_*.json` files.

### Impacts
This change primarily impacts developers who work on the [Open-edX Platform](https://github.com/openedx/edx-platform) and run the `unit-test` workflow files.

### Screenshots
No UI changes are associated with this pull request.

## Supporting information

For additional context, refer to [openedx/public-engineering Issue-107](https://github.com/openedx/public-engineering/issues/107) for a more detailed discussion on the deprecation warning and the necessity of this change.

## Testing instructions

To test this change:
1. Access the `unit-tests-gh-hosted` action/workflow for this pull request.
2. Open one of the recent runs for this workflow.
3. From the summary section, download the `pytest-warnings-json`.
4. Ensure that the deprecation warning related to `runtime.can_execute_unsafe_code` no longer appears in any of the `pytest-warning` files.

## Deadline

None.

## Other information

- No dependencies on other changes.
- No special concerns or limitations.
- No database migrations are involved.