### PR TITLE
issue-108: removing runtime.get_python_lib_zip deprecation warning

### DIFF
--- a/cms/djangoapps/contentstore/views/tests/test_preview.py
+++ b/cms/djangoapps/contentstore/views/tests/test_preview.py
@@ -264,7 +264,7 @@ class CmsModuleSystemShimTest(ModuleStoreTestCase):
             source_file=self.PYTHON_LIB_SOURCE_FILE,
             target_filename=self.PYTHON_LIB_FILENAME,
         )
-        assert self.block.runtime.get_python_lib_zip() == zipfile
+        assert self.block.runtime._services.get('sandbox').get_python_lib_zip() == zipfile  # lint-amnesty, pylint: disable=protected-access
 
     def test_no_get_python_lib_zip(self):
         zipfile = upload_file_to_course(
@@ -273,7 +273,7 @@ class CmsModuleSystemShimTest(ModuleStoreTestCase):
             source_file=self.PYTHON_LIB_SOURCE_FILE,
             target_filename=self.PYTHON_LIB_FILENAME,
         )
-        assert self.block.runtime.get_python_lib_zip() is None
+        assert self.block.runtime._services.get('sandbox').get_python_lib_zip() is None  # lint-amnesty, pylint: disable=protected-access
 
     def test_cache(self):
         assert hasattr(self.block.runtime.cache, 'get')

--- a/lms/djangoapps/courseware/tests/test_block_render.py
+++ b/lms/djangoapps/courseware/tests/test_block_render.py
@@ -2838,7 +2838,7 @@ class LmsModuleSystemShimTest(SharedModuleStoreTestCase):
             source_file=self.PYTHON_LIB_SOURCE_FILE,
             target_filename=self.PYTHON_LIB_FILENAME,
         )
-        assert self.block.runtime.get_python_lib_zip() == zipfile
+        assert self.block.runtime._services.get('sandbox').get_python_lib_zip() == zipfile  # lint-amnesty, pylint: disable=protected-access
 
     def test_no_get_python_lib_zip(self):
         zipfile = upload_file_to_course(
@@ -2847,7 +2847,7 @@ class LmsModuleSystemShimTest(SharedModuleStoreTestCase):
             source_file=self.PYTHON_LIB_SOURCE_FILE,
             target_filename=self.PYTHON_LIB_FILENAME,
         )
-        assert self.block.runtime.get_python_lib_zip() is None
+        assert self.block.runtime._services.get('sandbox').get_python_lib_zip() is None  # lint-amnesty, pylint: disable=protected-access
 
     def test_cache(self):
         assert hasattr(self.block.runtime.cache, 'get')


### PR DESCRIPTION
## Description

This pull request addresses [issue-108](https://github.com/openedx/public-engineering/issues/108) from the [openedx/public-engineering](https://github.com/openedx/public-engineering/issues) repository, removing the deprecation warning related to the use of `runtime.get_python_lib_zip` in the [edx-platform](https://github.com/openedx/edx-platform) codebase.

The warning "[Deprecation Warning]: runtime.get_python_lib_zip is deprecated. Please use the sandbox service instead." will no longer appear during GitHub Actions `unit-test` runs and in the `pytest-warnings` report.

This pull request removes 4 instances of the warning across 2`pytest_warnings_*.json` files.

### Impacts
This change primarily impacts developers who work on the [Open-edX Platform](https://github.com/openedx/edx-platform) and run the `unit-test` workflow files.

### Screenshots
No UI changes are associated with this pull request.

## Supporting information

For additional context, refer to [openedx/public-engineering Issue-108](https://github.com/openedx/public-engineering/issues/108) for a more detailed discussion on the deprecation warning and the necessity of this change.

## Testing instructions

To test this change:
1. Access the `unit-tests-gh-hosted` action/workflow for this pull request.
2. Open one of the recent runs for this workflow.
3. From the summary section, download the `pytest-warnings-json`.
4. Ensure that the deprecation warning related to `runtime.get_python_lib_zip` no longer appears in any of the `pytest-warning` files.

## Deadline

None.

## Other information

- No dependencies on other changes.
- No special concerns or limitations.
- No database migrations are involved.